### PR TITLE
#9: Fix bug in `std::call_once`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Contents:
     - [Sample Program](#sample-program)
     - [Using With pressio-rom](#using-with-pressio-rom)
 - [Testing](#testing)
+- [Thread Safety](#thread-safety)
 
 ## Logging Levels
 
@@ -225,3 +226,13 @@ ctest -j <np>
 
 > [!NOTE]
 > All MPI tests require at least three processors to run.
+
+## Thread Safety
+
+`pressio-log` is designed to be thread-safe. For example, logger initialization
+is protected using `std::call_once`, and all output is synchronized with a `std::mutex`.
+
+> [!WARNING]
+> If your compiler does not enable threading, these functionalities may cause runtime errors.
+> See [this issue](https://github.com/Pressio/pressio-log/issues/9) for more information and
+> [let us know](https://github.com/Pressio/pressio-log/issues/new) if you encounter any problems.

--- a/include/pressio-log/logger/logger.hpp
+++ b/include/pressio-log/logger/logger.hpp
@@ -161,8 +161,9 @@ class Logger {
 
         // Initialization
         std::atomic<bool> logger_is_initialized_{false};
-        std::once_flag init_flag_;
-        std::once_flag init_warning_flag_;
+        std::unique_ptr<std::once_flag> init_flag_ = std::make_unique<std::once_flag>();
+        std::unique_ptr<std::once_flag> init_warning_flag_ = std::make_unique<std::once_flag>();
+        std::mutex init_mutex_;
 
         // Configuration
         LogLevel logging_level_{LogLevel::none};


### PR DESCRIPTION
Fixes #9 

For now, this only cleans up initialization and adds a warning in the README about the bug. I've created #15 as a follow-on to ensure that the logger works even when threading is not enabled by the compiler.