### PR TITLE
#20: Allow string args in log template function

### DIFF
--- a/include/pressio-log/logger/logger_impl.hpp
+++ b/include/pressio-log/logger/logger_impl.hpp
@@ -119,7 +119,7 @@ inline void Logger::log(LogLevel level, const std::string& message) {
     if (current_rank_ == logging_rank_) {
         switch (level) {
             case LogLevel::none:    return;
-            case LogLevel::sparse:   sparse_(message);   break;
+            case LogLevel::sparse:  sparse_(message);   break;
             case LogLevel::info:    info_(message);    break;
             case LogLevel::debug:   debug_(message);   break;
             case LogLevel::warning: warning_(message); break;
@@ -136,7 +136,7 @@ inline void Logger::log(LogLevel level, const std::string& fmt_str, Args&&... ar
     } catch(const fmt::v11::format_error&) {
         std::ostringstream oss;
         oss << "fmt could not format given string: " << fmt_str << " with args:\n";
-        ((oss << "  " << std::to_string(args) << "\n"), ...);
+        ((oss << "  " << args << "\n"), ...);
         throw std::runtime_error(oss.str());
     }
 }

--- a/tests/logging/CMakeLists.txt
+++ b/tests/logging/CMakeLists.txt
@@ -13,6 +13,11 @@ add_utest_serial(
   ${CMAKE_CURRENT_SOURCE_DIR}/test_logger_write_serial.cc
 )
 
+add_utest_serial(
+  test_logger_string
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_logger_string.cc
+)
+
 if (PRESSIO_ENABLE_TPL_MPI)
   add_utest_mpi(
     test_logger_mpi gTestMain_mpi 3

--- a/tests/logging/test_logger_string.cc
+++ b/tests/logging/test_logger_string.cc
@@ -4,22 +4,23 @@
 #include "LoggerTest.hpp"
 #include "pressio-log/core.hpp"
 
-TEST_F(LoggerTest, Logger_String_Templated) {
+TEST_F(LoggerTest, Logger_String_Formatting) {
     PRESSIOLOG_SET_LEVEL(pressiolog::LogLevel::debug);
 
     CoutRedirector redirect;
 
     PRESSIOLOG_SPARSE("{}", "hey there");
-    PRESSIOLOG_INFO("{} {}", "two", "strings");
-    PRESSIOLOG_DEBUG("{}", "Debug");
-    PRESSIOLOG_WARNING("{}: {}", 2, "number");
-    PRESSIOLOG_ERROR("{}", "Error");
+    PRESSIOLOG_SPARSE("{} {}", "two", "strings");
+    PRESSIOLOG_SPARSE("{}", "Debug");
+    PRESSIOLOG_SPARSE("{}: {}", 2.1, "number");
+    PRESSIOLOG_SPARSE("{}", "Error");
 
     std::string output = redirect.str();
 
     EXPECT_TRUE(check_output(output, "hey there",   true));
     EXPECT_TRUE(check_output(output, "two strings", true));
     EXPECT_TRUE(check_output(output, "Debug",       true));
-    EXPECT_TRUE(check_output(output, "2: number",   true));
+    EXPECT_TRUE(check_output(output, "2.1: number",   true));
     EXPECT_TRUE(check_output(output, "Error",       true));
+    EXPECT_TRUE(check_output(output, "could not format given string",   false));
 }

--- a/tests/logging/test_logger_string.cc
+++ b/tests/logging/test_logger_string.cc
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+#include "helpers.hpp"
+#include "LoggerTest.hpp"
+#include "pressio-log/core.hpp"
+
+TEST_F(LoggerTest, Logger_String_Templated) {
+    PRESSIOLOG_SET_LEVEL(pressiolog::LogLevel::debug);
+
+    CoutRedirector redirect;
+
+    PRESSIOLOG_SPARSE("{}", "hey there");
+    PRESSIOLOG_INFO("{} {}", "two", "strings");
+    PRESSIOLOG_DEBUG("{}", "Debug");
+    PRESSIOLOG_WARNING("{}: {}", 2, "number");
+    PRESSIOLOG_ERROR("{}", "Error");
+
+    std::string output = redirect.str();
+
+    EXPECT_TRUE(check_output(output, "hey there",   true));
+    EXPECT_TRUE(check_output(output, "two strings", true));
+    EXPECT_TRUE(check_output(output, "Debug",       true));
+    EXPECT_TRUE(check_output(output, "2: number",   true));
+    EXPECT_TRUE(check_output(output, "Error",       true));
+}


### PR DESCRIPTION
I simply removed the ```std::to_string()``` call when printing out the arguments given an error. The ostringstream ```<<``` operator already handles strings, numeric types, and most other types, so we don't need to convert the args anyway.